### PR TITLE
Exposed task timeout as VcpkgTaskTimeout property

### DIFF
--- a/InstallTask.cs
+++ b/InstallTask.cs
@@ -58,7 +58,6 @@ namespace VcpkgBuildTask
                     )
                 ),
                 "vcpkg.exe");
-            Timeout = 10 * 60 * 1000;
 
             if (singleTaskCrit == null)
             {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vcpkg.nuget
 
-[vcpkg](https://github.com/microsoft/vcpkg) wrapped in [nuget](https://nuget.org)-y goodness 📦 
+[vcpkg](https://github.com/microsoft/vcpkg) wrapped in [nuget](https://nuget.org)-y goodness 📦
 
 ![build status](https://b3ngr33ni3r.visualstudio.com/_apis/public/build/definitions/947d98de-244b-4cdb-a49a-4b232d942edc/3/badge)
 
@@ -14,7 +14,7 @@ __Note: This only supports vcpkg running as part of msbuild, and therefore requi
 
 This package relies on `VcpkgPackage` msbuild tasks, that leverage the following format:
 
-```
+```xml
 <VcpkgPackage Include="packageName"/>
 ```
 
@@ -32,9 +32,10 @@ Where `packageName` refers to the [vcpkg port](https://github.com/Microsoft/vcpk
 * Install the [nuget package](https://www.nuget.org/packages/Vcpkg.Nuget/)
 * Import our build configuration in your project file:
 
-```
+```xml
 <Import Project="packages\Vcpkg.Nuget.1.0.0-beta\build\Vcpkg.Nuget.props" Condition="Exists('packages\Vcpkg.Nuget.1.0.0-beta\build\Vcpkg.Nuget.props')" />
 ```
+
 * Find the relevant ports you wish to install [here](https://github.com/Microsoft/vcpkg/tree/master/ports)
 * Add `VcpkgPackage` elements to your project file
 * Building will ensure ports are built and installed

--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ This package relies on `VcpkgPackage` msbuild tasks, that leverage the following
 
 Where `packageName` refers to the [vcpkg port](https://github.com/Microsoft/vcpkg/tree/master/ports) you wish to install.
 
+By default the task invoking vcpkg has a generous default timeout of ten minutes. If your package builds run longer than that, override the `VcpkgTaskTimeout` property with a higher value:
+
+```xml
+  <PropertyGroup>
+    <!-- task may run for up to twenty minutes -->
+    <VcpkgTaskTimeout>1200000</VcpkgTaskTimeout>
+  </PropertyGroup>
+```
+
 ### Using Visual Studio
 
 * Install the [nuget package](https://www.nuget.org/packages/Vcpkg.Nuget/)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 version: 1.4.{build}
 image: Visual Studio 2017
+install:
+- cmd: git submodule -q update --init
 build:
   parallel: false
   project: Vcpkg-Nuget.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,9 @@
 version: 1.4.{build}
 image: Visual Studio 2017
 install:
-- cmd: git submodule -q update --init
+- git submodule -q update --init
+before_build:
+- nuget restore
 build:
   parallel: false
   project: Vcpkg-Nuget.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.4.{build}
+version: 1.5.{build}
 image: Visual Studio 2017
 install:
 - git submodule -q update --init

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,5 @@
+version: 1.4.{build}
+image: Visual Studio 2017
+build:
+  parallel: false
+  project: Vcpkg-Nuget.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,5 @@ configuration: Release
 build:
   parallel: false
   project: Vcpkg-Nuget.sln
-#after_build:
-#  - msbuild nuget\nuget.vcxproj
 artifacts:
   - path: 'Release\*.nupkg'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,10 @@ install:
 - git submodule -q update --init
 before_build:
 - nuget restore
+platform: Any CPU
+configuration: Release
 build:
   parallel: false
   project: Vcpkg-Nuget.sln
+artifacts:
+  - path: '**\*.nupkg'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,5 +9,7 @@ configuration: Release
 build:
   parallel: false
   project: Vcpkg-Nuget.sln
+after_build:
+  - msbuild nuget\nuget.vcxproj
 artifacts:
-  - path: '**\*.nupkg'
+  - path: 'nuget\*.nupkg'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,12 +4,12 @@ install:
 - git submodule -q update --init
 before_build:
 - nuget restore
-platform: Any CPU
+platform: x86
 configuration: Release
 build:
   parallel: false
   project: Vcpkg-Nuget.sln
-after_build:
-  - msbuild nuget\nuget.vcxproj
+#after_build:
+#  - msbuild nuget\nuget.vcxproj
 artifacts:
-  - path: 'nuget\*.nupkg'
+  - path: 'Release\*.nupkg'

--- a/nuget/Vcpkg.Nuget.nuspec
+++ b/nuget/Vcpkg.Nuget.nuspec
@@ -5,7 +5,7 @@
     <id>Vcpkg.Nuget</id>
 
     <!-- The package version number that is used when resolving dependencies -->
-    <version>1.4.2</version>
+    <version>1.4.3</version>
 
     <!-- Authors contain text that appears directly on the gallery -->
     <authors>Ben Greenier</authors>

--- a/nuget/Vcpkg.Nuget.nuspec
+++ b/nuget/Vcpkg.Nuget.nuspec
@@ -5,7 +5,7 @@
     <id>Vcpkg.Nuget</id>
 
     <!-- The package version number that is used when resolving dependencies -->
-    <version>1.4.3</version>
+    <version>1.4.4</version>
 
     <!-- Authors contain text that appears directly on the gallery -->
     <authors>Ben Greenier</authors>

--- a/nuget/Vcpkg.Nuget.nuspec
+++ b/nuget/Vcpkg.Nuget.nuspec
@@ -5,7 +5,7 @@
     <id>Vcpkg.Nuget</id>
 
     <!-- The package version number that is used when resolving dependencies -->
-    <version>1.4.1</version>
+    <version>1.4.2</version>
 
     <!-- Authors contain text that appears directly on the gallery -->
     <authors>Ben Greenier</authors>

--- a/nuget/Vcpkg.Nuget.nuspec
+++ b/nuget/Vcpkg.Nuget.nuspec
@@ -5,7 +5,7 @@
     <id>Vcpkg.Nuget</id>
 
     <!-- The package version number that is used when resolving dependencies -->
-    <version>1.4.0</version>
+    <version>1.4.1</version>
 
     <!-- Authors contain text that appears directly on the gallery -->
     <authors>Ben Greenier</authors>

--- a/nuget/Vcpkg.Nuget.nuspec
+++ b/nuget/Vcpkg.Nuget.nuspec
@@ -5,7 +5,7 @@
     <id>Vcpkg.Nuget</id>
 
     <!-- The package version number that is used when resolving dependencies -->
-    <version>1.4.4</version>
+    <version>1.5.0</version>
 
     <!-- Authors contain text that appears directly on the gallery -->
     <authors>Ben Greenier</authors>

--- a/nuget/Vcpkg.Nuget.props
+++ b/nuget/Vcpkg.Nuget.props
@@ -3,12 +3,11 @@
   <Import Project="$(MsbuildThisFileDirectory)..\vcpkg_bin\scripts\buildsystems\msbuild\vcpkg.targets"/>
   <UsingTask TaskName="VcpkgBuildTask.InstallTask"
       AssemblyFile="$(MsbuildThisFileDirectory)VcpkgBuildTask.dll"/>
-  
-  <PropertyGroup>
-    <VcpkgTaskTimeout Condition="'$(VcpkgTaskTimeout)' == '' ">600000</VcpkgTaskTimeout>
-  </PropertyGroup>
 
   <Target Name="Vcpkg" BeforeTargets="PreBuildEvent">
+    <PropertyGroup>
+      <VcpkgTaskTimeout Condition="'$(VcpkgTaskTimeout)' == '' ">600000</VcpkgTaskTimeout>
+    </PropertyGroup>
     <Message Text="Running vcpkg..." Importance="high" Condition="@(VcpkgPackage) != ''"/>
     <Message Text="Skipping vcpkg. (no packages)" Importance="high" Condition="@(VcpkgPackage) == ''"/>
     <InstallTask Packages="@(VcpkgPackage)"

--- a/nuget/Vcpkg.Nuget.props
+++ b/nuget/Vcpkg.Nuget.props
@@ -4,7 +4,9 @@
   <UsingTask TaskName="VcpkgBuildTask.InstallTask"
       AssemblyFile="$(MsbuildThisFileDirectory)VcpkgBuildTask.dll"/>
   
-  <VcpkgTaskTimeout Condition="'$(VcpkgTaskTimeout)' == '' ">600000</VcpkgTaskTimeout>
+  <PropertyGroup>
+    <VcpkgTaskTimeout Condition="'$(VcpkgTaskTimeout)' == '' ">600000</VcpkgTaskTimeout>
+  </PropertyGroup>
 
   <Target Name="Vcpkg" BeforeTargets="PreBuildEvent">
     <Message Text="Running vcpkg..." Importance="high" Condition="@(VcpkgPackage) != ''"/>

--- a/nuget/Vcpkg.Nuget.props
+++ b/nuget/Vcpkg.Nuget.props
@@ -3,6 +3,8 @@
   <Import Project="$(MsbuildThisFileDirectory)..\vcpkg_bin\scripts\buildsystems\msbuild\vcpkg.targets"/>
   <UsingTask TaskName="VcpkgBuildTask.InstallTask"
       AssemblyFile="$(MsbuildThisFileDirectory)VcpkgBuildTask.dll"/>
+  
+  <VcpkgTaskTimeout Condition="'$(VcpkgTaskTimeout)' == '' ">600000</VcpkgTaskTimeout>
 
   <Target Name="Vcpkg" BeforeTargets="PreBuildEvent">
     <Message Text="Running vcpkg..." Importance="high" Condition="@(VcpkgPackage) != ''"/>
@@ -14,6 +16,7 @@
                  StandardErrorImportance="high"
                  VcpkgRoot="$(MsbuildThisFileDirectory)..\vcpkg_bin"
                  VcpkgExe="$(MsbuildThisFileDirectory)..\vcpkg_bin\vcpkg.exe"
-                 VcpkgTriplet="$(VcpkgTriplet)" />
+                 VcpkgTriplet="$(VcpkgTriplet)"
+                 Timeout="$(VcpkgTaskTimeout)" />
   </Target>
 </Project>

--- a/nuget/nuget.vcxproj
+++ b/nuget/nuget.vcxproj
@@ -22,7 +22,12 @@
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{5C91D4CC-745F-4369-85D2-3EC5FDF21FE8}</ProjectGuid>
     <RootNamespace>nuget</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(WindowsTargetPlatformVersion)'==''">
+    <!-- Latest Target Version property -->
+    <LatestTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</LatestTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
+    <TargetPlatformVersion>$(WindowsTargetPlatformVersion)</TargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/tests/InstallTaskTests.cs
+++ b/tests/InstallTaskTests.cs
@@ -17,7 +17,7 @@ namespace VcpkgBuildTask.Tests
         {
             var instance = new InstallTask();
 
-            Assert.AreEqual(10 * 60 * 1000, instance.Timeout);
+            //Assert.AreEqual(10 * 60 * 1000, instance.Timeout);
             Assert.IsNotNull(instance.VcpkgExe);
         }
 


### PR DESCRIPTION
More heavy-weight packages may cause the Vcpkg task to run into the hard-coded timeout of 10 minutes. This change attempts to expose this value to the developer as `VcpkgTaskTimeout` which can be overridden in the project file.